### PR TITLE
feat(HR): thêm hồ sơ mới

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -90,6 +90,7 @@ function App() {
                 </PrivateRoute>
               }
             />
+
             <Route
               path="/hr/approve-docs"
               element={

--- a/src/api/hrApi.js
+++ b/src/api/hrApi.js
@@ -38,6 +38,32 @@ const hrApi = {
     return res.data;
   },
 
+createInternProfile: async (token, userId, profileData) => {
+  const formData = new FormData();
+  formData.append("fullName", profileData.full_name);
+  formData.append("gender", profileData.gender);
+  formData.append("dob", profileData.dob);
+  formData.append("major", profileData.major);
+  formData.append("gpa", profileData.gpa);
+  formData.append("school", "CMC University");
+  formData.append("phoneNumber", profileData.phone);
+  formData.append("address", profileData.address);
+
+  const res = await axios.post(`${API_URL}/${userId}/profile`, formData, {
+    ...authHeader(token),
+  });
+  return res.data;
+},
+
+
+getInternCandidatesWithoutProfile: async (token, page = 0, size = 10) => {
+  const response = await axios.get(`${API_URL}/candidates`, {
+    ...authHeader(token),
+    params: { page, size },
+  });
+  return response.data;
+},
+
 };
 
 export default hrApi;

--- a/src/context/HrContext.jsx
+++ b/src/context/HrContext.jsx
@@ -1,0 +1,82 @@
+import React, { createContext, useState, useEffect, useContext } from "react";
+import {
+  getAllInterns,
+  createIntern,
+  updateIntern,
+  deleteIntern,
+} from "../api/hrApi";
+import { AuthContext } from "./AuthContext";
+import { searchInterns, getMajors } from "../api/hrApi";
+
+export const HrContext = createContext();
+
+export const HrProvider = ({ children }) => {
+  const { token, loading: authLoading } = useContext(AuthContext);
+  const [interns, setInterns] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  // Fetch interns
+  const fetchInterns = async () => {
+    if (!token) return;
+    setLoading(true);
+    try {
+      const data = await getAllInterns(token);
+      setInterns(data.content);
+      setError(null);
+    } catch (err) {
+      console.error("Lấy danh sách intern thất bại:", err);
+      setError("Không thể tải danh sách thực tập sinh");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!authLoading && token) fetchInterns();
+  }, [authLoading, token]);
+
+  const addIntern = async (internProfile) => {
+    const newIntern = await createIntern(token, internProfile);
+    setInterns((prev) => [...prev, newIntern]);
+  };
+
+const editIntern = async (id, internProfile) => {
+  const updated = await updateIntern(token, id, internProfile);
+  setInterns((prev) =>
+    prev.map((i) => (i.internId === id ? updated : i))
+  );
+};
+
+const removeIntern = async (id) => {
+  await deleteIntern(token, id);
+  setInterns((prev) => prev.filter((i) => i.internId !== id));
+};
+const searchInternList = async (filters) => {
+  const data = await searchInterns(token, filters);
+  setInterns(data.content);
+};
+
+const fetchMajors = async () => {
+  return await getMajors(token);
+};
+
+  return (
+    <HrContext.Provider
+      value={{
+        interns,
+        setInterns,
+        loading,
+        error,
+        fetchInterns,
+        addIntern,
+        editIntern,
+        removeIntern,
+        searchInternList,
+        fetchMajors,
+      }}
+    >
+      {children}
+    </HrContext.Provider>
+  );
+};

--- a/src/pages/HR/ManageInterns/CandidatesModal.jsx
+++ b/src/pages/HR/ManageInterns/CandidatesModal.jsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState, useContext } from "react";
+import hrApi from "../../../api/hrApi";
+import { AuthContext } from "../../../context/AuthContext";
+import ProfileModal from "./modals/ProfileModal";
+import Modal from "../../../components/Layout/Modal";
+import "../../../styles/buttons.css";
+
+const CandidatesModal = ({ onClose }) => {
+  const { token } = useContext(AuthContext);
+  const [candidates, setCandidates] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedCandidate, setSelectedCandidate] = useState(null);
+  const [profileData, setProfileData] = useState({});
+  const [errors, setErrors] = useState({});
+
+  useEffect(() => {
+    const fetchCandidates = async () => {
+      try {
+        const res = await hrApi.getInternCandidatesWithoutProfile(token, 0, 10);
+        setCandidates(res.content || []);
+      } catch (err) {
+        console.error("Error fetching candidates:", err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchCandidates();
+  }, [token]);
+
+  const handleOpenProfileModal = (candidate) => {
+    setSelectedCandidate(candidate);
+    setProfileData({
+      full_name: candidate.fullName,
+      phone: candidate.phone || "",
+      major: "",
+      gpa: "",
+      address: "",
+      gender: "",
+      dob: "",
+      photo_path: null,
+      documents: []
+    });
+  };
+const formatDateToISO = (dateStr) => {
+  if (dateStr.includes("/")) {
+    const [day, month, year] = dateStr.split("/");
+    return `${year}-${month}-${day}`;
+  }
+  return dateStr;
+};
+
+  const handleSubmitProfile = async () => {
+    const newErrors = {};
+const dobISO = formatDateToISO(profileData.dob);
+profileData.dob = dobISO;
+
+    if (!profileData.full_name || profileData.full_name.trim().length < 2) {
+      newErrors.full_name = "Họ tên phải có ít nhất 2 ký tự";
+    }
+
+    if (!profileData.gender) {
+      newErrors.gender = "Vui lòng chọn giới tính";
+    }
+
+    if (!profileData.dob) {
+      newErrors.dob = "Ngày sinh bắt buộc";
+    } else if (new Date(profileData.dob) >= new Date()) {
+      newErrors.dob = "Ngày sinh phải là ngày trong quá khứ";
+    }
+
+    if (!profileData.major) {
+      newErrors.major = "Vui lòng chọn ngành";
+    }
+
+    if (!profileData.gpa || profileData.gpa <= 0 || profileData.gpa > 4) {
+      newErrors.gpa = "GPA phải nằm trong khoảng 0.01 - 4.0";
+    }
+
+    if (!profileData.phone || !/^0\d{9}$/.test(profileData.phone)) {
+      newErrors.phone = "Số điện thoại phải từ 9-11 chữ số";
+    }
+
+    if (!profileData.address || profileData.address.trim().length < 5) {
+      newErrors.address = "Địa chỉ phải có ít nhất 5 ký tự";
+    }
+
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
+      return;
+    }
+
+    try {
+      await hrApi.createInternProfile(token, selectedCandidate.userId, profileData);
+      setSelectedCandidate(null);
+      onClose();
+    } catch (err) {
+      console.error("Error creating profile:", err);
+    }
+  };
+
+
+  return (
+<Modal title="Ứng viên chưa có hồ sơ" onClose={onClose} className="modal-large">
+      {loading ? (
+        <p>Đang tải...</p>
+      ) : (
+        <table className="users-table">
+          <thead>
+            <tr>
+              <th>STT</th>
+              <th>Họ tên</th>
+              <th>Email</th>
+              <th>Số điện thoại</th>
+              <th>Hành động</th>
+            </tr>
+          </thead>
+          <tbody>
+            {candidates.map((c, idx) => (
+              <tr key={c.userId}>
+                <td>{idx + 1}</td>
+                <td>{c.fullName}</td>
+                <td>{c.email}</td>
+                <td>{c.phone}</td>
+                <td>
+                  <button className="btn-primary" onClick={() => handleOpenProfileModal(c)}>➕ Thêm hồ sơ</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {selectedCandidate && (
+        <ProfileModal
+          isEdit={false}
+          intern={selectedCandidate}
+          profileData={profileData}
+          setProfileData={setProfileData}
+          onClose={() => setSelectedCandidate(null)}
+          onSubmit={handleSubmitProfile}
+          errors={errors}
+        />
+      )}
+    </Modal>
+  );
+};
+
+export default CandidatesModal;

--- a/src/pages/HR/ManageInterns/ManageInterns.jsx
+++ b/src/pages/HR/ManageInterns/ManageInterns.jsx
@@ -4,6 +4,8 @@ import HRInternTable from "./component/HRInternTable";
 import HRSidebar from "../../../components/Layout/HRSidebar";
 import { AuthContext } from "../../../context/AuthContext";
 import HRInternHeader from "./component/HRInternHeader";
+import { useNavigate } from "react-router-dom";
+import CandidatesModal from "./CandidatesModal";
 
 const ManageInterns = () => {
   const { token } = useContext(AuthContext);
@@ -14,10 +16,12 @@ const ManageInterns = () => {
   const [statusFilter, setStatusFilter] = useState("");
   const [majorFilter, setMajorFilter] = useState("");
 
-  // thêm state cho phân trang
+  // phân trang
   const [page, setPage] = useState(0);
   const [size, setSize] = useState(10);
   const [totalPages, setTotalPages] = useState(0);
+
+  const [showCandidatesModal, setShowCandidatesModal] = useState(false);
 
   const fetchInterns = async () => {
     try {
@@ -39,7 +43,6 @@ const ManageInterns = () => {
         res = await hrApi.getAllInterns(token, page, size);
       }
 
-      // res là object Page
       setInterns(res.content || []);
       setTotalPages(res.totalPages || 0);
     } catch (err) {
@@ -62,6 +65,10 @@ const ManageInterns = () => {
     fetchInterns();
   };
 
+  const handleAddProfilePage = () => {
+    setShowCandidatesModal(true);
+  };
+
   if (loading) return <p>Đang tải dữ liệu...</p>;
 
   return (
@@ -76,13 +83,17 @@ const ManageInterns = () => {
           majorFilter={majorFilter}
           setMajorFilter={setMajorFilter}
           onClearFilters={handleClearFilters}
+          onAdd={handleAddProfilePage}
         />
         <HRInternTable interns={interns} page={page} size={size} fetchInterns={fetchInterns} />
 
-        {/* Pagination controls */}
+        {showCandidatesModal && (
+          <CandidatesModal onClose={() => setShowCandidatesModal(false)} />
+        )}
+
         <div className="pagination">
           <button
-            className={`pagination-btn ${page === 0 ? "" : ""}`}
+            className="pagination-btn"
             disabled={page === 0}
             onClick={() => setPage(page - 1)}
           >
@@ -94,7 +105,7 @@ const ManageInterns = () => {
           </span>
 
           <button
-            className={`pagination-btn ${page + 1 >= totalPages ? "" : ""}`}
+            className="pagination-btn"
             disabled={page + 1 >= totalPages}
             onClick={() => setPage(page + 1)}
           >

--- a/src/pages/HR/ManageInterns/modals/ProfileModal.jsx
+++ b/src/pages/HR/ManageInterns/modals/ProfileModal.jsx
@@ -7,25 +7,24 @@ const ProfileModal = ({ isEdit, intern, profileData, setProfileData, onClose, on
     {/* Họ tên */}
     <div className="form-group">
       <label>Họ tên *</label>
-      <input className="form-input" value={profileData.full_name} onChange={e => setProfileData({...profileData, full_name: e.target.value})}/>
+      <input
+        className="form-input"
+        value={profileData.full_name}
+        onChange={e => setProfileData({ ...profileData, full_name: e.target.value })}
+      />
       {errors.full_name && <p className="field-error">{errors.full_name}</p>}
-    </div>
-
-    {/* Ảnh hồ sơ */}
-    <div className="form-group">
-      <label>Ảnh hồ sơ *</label>
-      <input type="file" accept="image/*" onChange={e => setProfileData({...profileData, photo_path: e.target.files[0]})}/>
-      {errors.photo_path && <p className="field-error">{errors.photo_path}</p>}
-      {profileData.photo_path && <p>Đã chọn: {profileData.photo_path.name}</p>}
     </div>
 
     {/* Giới tính */}
     <div className="form-group">
       <label>Giới tính *</label>
-      <select className="form-input" value={profileData.gender} onChange={e => setProfileData({...profileData, gender: e.target.value})}>
-        <option value="Nam">Nam</option>
-        <option value="Nữ">Nữ</option>
-        <option value="Khác">Khác</option>
+      <select
+        className="form-input"
+        value={profileData.gender}
+        onChange={e => setProfileData({ ...profileData, gender: e.target.value })}
+      >
+        <option value="MALE">Nam</option>
+        <option value="FEMALE">Nữ</option>
       </select>
       {errors.gender && <p className="field-error">{errors.gender}</p>}
     </div>
@@ -33,24 +32,38 @@ const ProfileModal = ({ isEdit, intern, profileData, setProfileData, onClose, on
     {/* Ngày sinh */}
     <div className="form-group">
       <label>Ngày sinh *</label>
-      <input type="date" className="form-input" value={profileData.dob} onChange={e => setProfileData({...profileData, dob: e.target.value})}/>
+      <input
+        type="date"
+        className="form-input"
+        value={profileData.dob}
+        onChange={e => setProfileData({ ...profileData, dob: e.target.value })}
+      />
       {errors.dob && <p className="field-error">{errors.dob}</p>}
     </div>
 
-    {/* Trường */}
+    {/* Trường (mặc định CMC University) */}
     <div className="form-group">
       <label>Trường *</label>
-      <input className="form-input" value={profileData.school} readOnly/>
+      <input
+        className="form-input"
+        value="CMC University"
+        readOnly
+      />
     </div>
 
     {/* Ngành */}
     <div className="form-group">
       <label>Ngành *</label>
-      <select className="form-input" value={profileData.major} onChange={e => setProfileData({...profileData, major: e.target.value})}>
+      <select
+        className="form-input"
+        value={profileData.major}
+        onChange={e => setProfileData({ ...profileData, major: e.target.value })}
+      >
         <option value="">-- Chọn ngành --</option>
-        <option value="CNTT">Công nghệ thông tin</option>
-        <option value="QTKD">Quản trị kinh doanh</option>
-        <option value="TKDH">Thiết kế đồ họa</option>
+        <option value="Công nghệ thông tin">Công nghệ thông tin</option>
+        <option value="Quản trị kinh doanh">Quản trị kinh doanh</option>
+        <option value="Thiết kế đồ họa">Thiết kế đồ họa</option>
+        <option value="Phân tích dữ liệu">Phân tích dữ liệu</option>
       </select>
       {errors.major && <p className="field-error">{errors.major}</p>}
     </div>
@@ -58,46 +71,39 @@ const ProfileModal = ({ isEdit, intern, profileData, setProfileData, onClose, on
     {/* GPA */}
     <div className="form-group">
       <label>GPA</label>
-      <input type="number" step="0.01" min="0.01" max="4" className="form-input" value={profileData.gpa} onChange={e => setProfileData({...profileData, gpa: e.target.value})}/>
+      <input
+        type="number"
+        step="0.01"
+        min="0.01"
+        max="4"
+        className="form-input"
+        value={profileData.gpa}
+        onChange={e => setProfileData({ ...profileData, gpa: e.target.value })}
+      />
       {errors.gpa && <p className="field-error">{errors.gpa}</p>}
     </div>
 
     {/* Số điện thoại */}
     <div className="form-group">
       <label>Số điện thoại *</label>
-      <input className="form-input" value={profileData.phone} onChange={e => setProfileData({...profileData, phone: e.target.value})} placeholder="Ví dụ: 0987654321"/>
+      <input
+        className="form-input"
+        value={profileData.phone}
+        onChange={e => setProfileData({ ...profileData, phone: e.target.value })}
+        placeholder="Ví dụ: 0987654321"
+      />
       {errors.phone && <p className="field-error">{errors.phone}</p>}
     </div>
 
     {/* Địa chỉ */}
     <div className="form-group">
       <label>Địa chỉ *</label>
-      <input className="form-input" value={profileData.address} onChange={e => setProfileData({...profileData, address: e.target.value})}/>
-      {errors.address && <p className="field-error">{errors.address}</p>}
-    </div>
-
-    {/* Tài liệu */}
-    <div className="form-group">
-      <label>Upload tài liệu (CV, Đơn xin TT)</label>
       <input
-        type="file"
-        multiple
-        accept=".pdf,.doc,.docx"
-        onChange={e => setProfileData({
-          ...profileData,
-          documents: [
-            ...(profileData.documents || []),
-            ...Array.from(e.target.files)
-          ]
-        })}
+        className="form-input"
+        value={profileData.address}
+        onChange={e => setProfileData({ ...profileData, address: e.target.value })}
       />
-      {profileData.documents && profileData.documents.length > 0 && (
-        <ul className="file-list">
-          {profileData.documents.map((file, idx) => (
-            <li key={idx}>{file.name}</li>
-          ))}
-        </ul>
-      )}
+      {errors.address && <p className="field-error">{errors.address}</p>}
     </div>
 
     {/* Nút hành động */}

--- a/src/styles/modal.css
+++ b/src/styles/modal.css
@@ -24,7 +24,7 @@
   backdrop-filter: blur(20px);
   border-radius: 15px;
   padding: 30px;
-  max-width: 500px;
+  max-width: 900px;
   width: 90%;
   max-height: 85vh;
   overflow-y: auto;


### PR DESCRIPTION
- Thêm endpoint POST /api/hr/interns/{userId}/profile để HR tạo hồ sơ thực tập sinh mới.
- Service HRService.createInternProfileForUser gán userId, set status mặc định = "NO_FILE" và lưu vào bảng intern_users.
- Controller trả về InternProfile vừa tạo để frontend có thể nhận dữ liệu ngay.
- Fix repository để hỗ trợ query ứng viên chưa có hồ sơ.